### PR TITLE
Replace arrows in snapshot test to work in github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,9 @@ on: [push]
 
 jobs:
   main:
+    env:
+      FORCE_COLOR: true
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/tests/__snapshots__/list.test.ts.snap
+++ b/tests/__snapshots__/list.test.ts.snap
@@ -2,18 +2,18 @@
 
 exports[`lists files from root level pages 1`] = `
 [
-  "/pages/api/[32mfile-no-comments.ts[39m ----> [35mNOT_FOUND[39m",
-  "/pages/api/[32mfile1.ts[39m ---------------> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
-  "/pages/api/nested/[32ma.ts[39m ------------> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
-  "/pages/api/nested/[32mb.ts[39m ------------> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
+  "/pages/api/[32mfile-no-comments.ts[39m -> [35mNOT_FOUND[39m",
+  "/pages/api/[32mfile1.ts[39m -> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
+  "/pages/api/nested/[32ma.ts[39m -> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
+  "/pages/api/nested/[32mb.ts[39m -> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
 ]
 `;
 
 exports[`lists files from src level pages 1`] = `
 [
-  "/pages/api/[32mfile-no-comments.ts[39m ----> [35mNOT_FOUND[39m",
-  "/pages/api/[32mfile1.ts[39m ---------------> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
-  "/pages/api/nested/[32ma.ts[39m ------------> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
-  "/pages/api/nested/[32mb.ts[39m ------------> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
+  "/pages/api/[32mfile-no-comments.ts[39m -> [35mNOT_FOUND[39m",
+  "/pages/api/[32mfile1.ts[39m -> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
+  "/pages/api/nested/[32ma.ts[39m -> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
+  "/pages/api/nested/[32mb.ts[39m -> [34mGET[39m|[33mPOST[39m|[33mPUT[39m|[31mDELETE[39m",
 ]
 `;

--- a/tests/list.test.ts
+++ b/tests/list.test.ts
@@ -1,10 +1,13 @@
 import { it, expect } from 'vitest'
 import { list } from '../lib/list'
+import { replaceArrows } from './replaceArrows'
 
 it('lists files from root level pages', async () => {
-  expect(await list({ path: 'tests/fixtures/root-level-pages' })).toMatchSnapshot()
+  const res = (await list({ path: 'tests/fixtures/root-level-pages' })).map(replaceArrows)
+  expect(res).toMatchSnapshot()
 })
 
 it('lists files from src level pages', async () => {
-  expect(await list({ path: 'tests/fixtures/src-level-pages' })).toMatchSnapshot()
+  const res = (await list({ path: 'tests/fixtures/src-level-pages' })).map(replaceArrows)
+  expect(res).toMatchSnapshot()
 })

--- a/tests/replaceArrows.ts
+++ b/tests/replaceArrows.ts
@@ -1,0 +1,4 @@
+// regex to replace replace -------> with ->
+const regex = /(-*)>/
+
+export const replaceArrows = (str: string): string => str.replace(regex, '->')


### PR DESCRIPTION
This is a follow up to fix the failing tests from #13.

I couldn't figure out why the number of dashes in the `--->` output is different when running the `list` tests locally vs in github actions. To workaround this I replace all the `---->` with a `->` irrelevant of how many dashes it contains when running the test.